### PR TITLE
Upgrade to ImageSharp 3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,8 +31,8 @@
     <PackageVersion Include="NumSharp" Version="0.30.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="SimpleSIMD" Version="3.3.1" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="2.1.4" />
-    <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.2" />
+    <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Interactive" Version="6.0.1" />
     <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />

--- a/src/FaceAiSharp.Validation/GenerateEmbeddings.cs
+++ b/src/FaceAiSharp.Validation/GenerateEmbeddings.cs
@@ -136,7 +136,7 @@ internal sealed class GenerateEmbeddings : IDisposable
     {
         var img = Image.Load<Rgb24>(filePath);
         var dets = _det.DetectFaces(img);
-        var imgCenter = RectangleF.Center(img.Bounds());
+        var imgCenter = RectangleF.Center(img.Bounds);
         var middleFace = dets.MinBy(x => RectangleF.Center(x.Box).EuclideanDistance(imgCenter));
         Debug.Assert(middleFace.Landmarks != null, "No landmarks detected but required");
         var (leye, reye) = (ScrfdDetector.GetLeftEye(middleFace.Landmarks), ScrfdDetector.GetRightEye(middleFace.Landmarks));
@@ -149,7 +149,7 @@ internal sealed class GenerateEmbeddings : IDisposable
     {
         var img = Image.Load<Rgb24>(filePath);
         var dets = _det.DetectFaces(img);
-        var imgCenter = RectangleF.Center(img.Bounds());
+        var imgCenter = RectangleF.Center(img.Bounds);
         var middleFace = dets.MinBy(x => RectangleF.Center(x.Box).EuclideanDistance(imgCenter));
         img.CropAlignedDestructive(Rectangle.Round(middleFace.Box), 0, 112);
         return img;
@@ -165,7 +165,7 @@ internal sealed class GenerateEmbeddings : IDisposable
     {
         var img = Image.Load<Rgb24>(filePath);
         var dets = _det.DetectFaces(img);
-        var imgCenter = RectangleF.Center(img.Bounds());
+        var imgCenter = RectangleF.Center(img.Bounds);
         var middleFace = dets.MinBy(x => RectangleF.Center(x.Box).EuclideanDistance(imgCenter));
         Debug.Assert(middleFace.Landmarks != null, "No landmarks detected but required");
         _emb.AlignFaceUsingLandmarks(img, middleFace.Landmarks);

--- a/src/FaceAiSharp/Applications.cs
+++ b/src/FaceAiSharp/Applications.cs
@@ -26,7 +26,7 @@ public static class Applications
             foreach (var fc in res)
             {
                 var r = Rectangle.Round(fc.Box);
-                r.Intersect(input.Bounds());
+                r.Intersect(input.Bounds);
                 var max = Math.Max(r.Width, r.Height);
                 var sigma = Math.Max(max / blurSigmaFactor, blurSigmaFactor);
                 op.GaussianBlur(sigma, r);
@@ -47,7 +47,7 @@ public static class Applications
         var maxFace = res.MaxBy(x => x.Confidence);
         var r = Rectangle.Round(maxFace.Box);
         r = r.ScaleCentered(scaleFactor);
-        r.Intersect(input.Bounds());
+        r.Intersect(input.Bounds);
         var angl = 0.0f;
         if (maxFace.Landmarks is not null && detector is IFaceDetectorWithLandmarks lmdet)
         {

--- a/src/FaceAiSharp/ScrfdDetector.cs
+++ b/src/FaceAiSharp/ScrfdDetector.cs
@@ -90,10 +90,10 @@ public sealed class ScrfdDetector : IFaceDetectorWithLandmarks, IDisposable
 
         (var img, var disp) = image.EnsureProperlySized<Rgb24>(resizeOptions, !Options.AutoResizeInputToModelDimensions);
         using var usingDisp = disp;
-        var scale = 1 / image.Bounds().GetScaleFactorToFitInto(resizeOptions.Size);
+        var scale = 1 / image.Bounds.GetScaleFactorToFitInto(resizeOptions.Size);
 
         var input = CreateImageTensor(img);
-        return Detect(input, img.Size(), scale);
+        return Detect(input, img.Size, scale);
     }
 
     IReadOnlyList<PointF> IFaceLandmarksDetector.DetectLandmarks(Image<Rgb24> image) => DetectFaces(image).MaxBy(x => x.Confidence).Landmarks!;


### PR DESCRIPTION
This pull request focuses on the integration of ImageSharp 3.

Brief summarization of the contents of this pull request:
- bump SixLabors.ImageSharp to 3.1.2
- SixLabors.ImageSharp.Drawing to 2.1.0
- adjust Bounds and Size function calls to use properties instead

I've run the tests located in the FaceAiSharp.Tests project to assure this does not introduce breaking behaviors. 
This might introduce breaking changes in consumers that do use SixLabors.ImageSharp 2, but vice versa this fixes a runtime error when the consumer uses SixLabors.ImageSharp 3. The SixLabors.ImageSharp.ImageInfoExtensions were removed from the library which then causes as TypeLoaderException.  