### PR TITLE
Quick wins: single-file deployment fix, README in nupkgs, better error handling

### DIFF
--- a/src/FaceAiSharp.Bundle/FaceAiSharp.Bundle.csproj
+++ b/src/FaceAiSharp.Bundle/FaceAiSharp.Bundle.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>FaceAiSharp.Bundle</AssemblyName>
     <Authors>Georg Jung</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <PackageTags>face;face-detection;face-recognition;scrfd;arcface;onnx;onnxruntime;ai;artificial-intelligence;ml;machine-learning;openvino;insightface;facial-landmarks-detection;eye-state-detection;eyes;lfw;widerface;face-ai;bundle</PackageTags>
     <PackageProjectUrl>https://github.com/georg-jung/FaceAiSharp</PackageProjectUrl>
@@ -21,6 +22,10 @@ FaceAiSharp allows you to work with face-related computer vision tasks easily. I
 This is a bundle package that installs FaceAiSharp's managed code and multiple AI models in the ONNX format.
     </PackageDescription>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FaceAiSharp.Models.Scrfd.2dot5g_kps" PrivateAssets="none" />

--- a/src/FaceAiSharp.Bundle/FaceAiSharpBundleFactory.cs
+++ b/src/FaceAiSharp.Bundle/FaceAiSharpBundleFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Georg Jung. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reflection;
 using Microsoft.ML.OnnxRuntime;
 
 namespace FaceAiSharp;
@@ -33,5 +32,7 @@ public static class FaceAiSharpBundleFactory
         return new OpenVinoOpenClosedEye0001(opt, sessionOptions);
     }
 
-    private static string GetExeDir() => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+    /* AppContext.BaseDirectory works in single-file and self-contained deployments too,
+     * where Assembly.Location returns an empty string. */
+    private static string GetExeDir() => AppContext.BaseDirectory;
 }

--- a/src/FaceAiSharp.FaceONNX/FaceAiSharp.FaceONNX.csproj
+++ b/src/FaceAiSharp.FaceONNX/FaceAiSharp.FaceONNX.csproj
@@ -12,7 +12,12 @@
     <AssemblyName>FaceAiSharp.FaceONNX</AssemblyName>
     <Authors>Georg Jung</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FaceONNX" />

--- a/src/FaceAiSharp.Tests/NonMaxSupressionCorrectness.cs
+++ b/src/FaceAiSharp.Tests/NonMaxSupressionCorrectness.cs
@@ -67,7 +67,7 @@ public class NonMaxSupressionCorrectness
 
     private static void TestInput(NDArray input, float thresh)
     {
-        var res1 = ScrfdDetector.NonMaxSupression(NDArray2FaceDetectorResults(input), thresh);
+        var res1 = ScrfdDetector.NonMaxSuppression(NDArray2FaceDetectorResults(input), thresh);
         var res2 = FromScrfdPy(input, thresh);
         Assert.Equal(res1, res2);
     }

--- a/src/FaceAiSharp/ArcFaceEmbeddingsGenerator.cs
+++ b/src/FaceAiSharp/ArcFaceEmbeddingsGenerator.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Georg Jung. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using System.Numerics;
 using CommunityToolkit.Diagnostics;
 using FaceAiSharp.Extensions;
@@ -198,7 +197,10 @@ public sealed class ArcFaceEmbeddingsGenerator : IFaceEmbeddingsGenerator, IDisp
         using var outputs = _session.Run(inputs);
         var firstOut = outputs.First();
         var tens = firstOut.Value as DenseTensor<float> ?? firstOut.AsTensor<float>().ToDenseTensor();
-        Debug.Assert(tens.Length % 512 == 0, "Output tensor length is invalid.");
+        if (tens.Length % 512 != 0)
+        {
+            throw new InvalidOperationException($"The output tensor has an invalid length of {tens.Length}. A multiple of 512 was expected. The model used is probably not supported.");
+        }
 
         var embSpan = tens.Buffer.Span;
         return GeometryExtensions.ToUnitLength(embSpan);

--- a/src/FaceAiSharp/FaceAiSharp.csproj
+++ b/src/FaceAiSharp/FaceAiSharp.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>FaceAiSharp</AssemblyName>
     <Authors>Georg Jung</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <PackageTags>face;face-detection;face-recognition;scrfd;arcface;onnx;onnxruntime;ai;artificial-intelligence;ml;machine-learning;openvino;insightface;facial-landmarks-detection;eye-state-detection;eyes;lfw;widerface;face-ai</PackageTags>
     <PackageProjectUrl>https://github.com/georg-jung/FaceAiSharp</PackageProjectUrl>
@@ -21,6 +22,10 @@ FaceAiSharp allows you to work with face-related computer vision tasks easily. I
 This package contains just FaceAiSharp's managed code and does not include any ONNX models. Take a look at FaceAiSharp.Bundle for a batteries-included package with everything you need to get started.
     </PackageDescription>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" />

--- a/src/FaceAiSharp/OpenVinoOpenClosedEye0001.cs
+++ b/src/FaceAiSharp/OpenVinoOpenClosedEye0001.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Georg Jung. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using FaceAiSharp.Extensions;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
@@ -64,7 +63,10 @@ public sealed class OpenVinoOpenClosedEye0001 : IEyeStateDetector, IDisposable
         using var outputs = _session.Run(inputs);
         var firstOut = outputs.First();
         var tens = firstOut.Value as DenseTensor<float> ?? firstOut.AsTensor<float>().ToDenseTensor();
-        Debug.Assert(tens.Length % 2 == 0, "Output tensor length is invalid.");
+        if (tens.Length % 2 != 0)
+        {
+            throw new InvalidOperationException($"The output tensor has an invalid length of {tens.Length}. A multiple of 2 was expected. The model used is probably not supported.");
+        }
 
         var span = tens.Buffer.Span;
         return span[0] < span[1];

--- a/src/FaceAiSharp/ScrfdDetector.cs
+++ b/src/FaceAiSharp/ScrfdDetector.cs
@@ -37,7 +37,6 @@ public sealed class ScrfdDetector : IFaceDetectorWithLandmarks, IDisposable
     /// Initializes a new instance of the <see cref="ScrfdDetector"/> class.
     /// </summary>
     /// <param name="model">An scrfd onnx model that supports facial landmarks ("kps").</param>
-    /// <param name="cache">An <see cref="IMemoryCache"/> instance that is used internally by <see cref="ScrfdDetector"/>.</param>
     /// <param name="options">Options to customize the behaviour of <see cref="ScrfdDetector"/>. If options.ModelPath is set, it is ignored. The model provided in <paramref name="model"/> takes precedence.</param>
     /// <param name="sessionOptions"><see cref="SessionOptions"/> to customize OnnxRuntime's behaviour.</param>
     public ScrfdDetector(byte[] model, ScrfdDetectorOptions? options = null, SessionOptions? sessionOptions = null)
@@ -90,7 +89,17 @@ public sealed class ScrfdDetector : IFaceDetectorWithLandmarks, IDisposable
         return Detect(input, img.Size, scale);
     }
 
-    IReadOnlyList<PointF> IFaceLandmarksDetector.DetectLandmarks(Image<Rgb24> image) => DetectFaces(image).MaxBy(x => x.Confidence).Landmarks!;
+    IReadOnlyList<PointF> IFaceLandmarksDetector.DetectLandmarks(Image<Rgb24> image)
+    {
+        var faces = DetectFaces(image);
+        if (faces.Count == 0)
+        {
+            throw new ArgumentException("No faces could be found in the given image.", nameof(image));
+        }
+
+        var best = faces.MaxBy(x => x.Confidence);
+        return best.Landmarks ?? throw new NotSupportedException("The model used does not support facial landmarks.");
+    }
 
     PointF IFaceLandmarksDetector.GetLeftEyeCenter(IReadOnlyList<PointF> landmarks) => GetLeftEye(landmarks);
 
@@ -106,7 +115,7 @@ public sealed class ScrfdDetector : IFaceDetectorWithLandmarks, IDisposable
     /// <param name="orderedResults">All detections.</param>
     /// <param name="thresh">Non max suppression threshold.</param>
     /// <returns>Which detections to keep.</returns>
-    internal static List<int> NonMaxSupression(IReadOnlyList<FaceDetectorResult> orderedResults, float thresh)
+    internal static List<int> NonMaxSuppression(IReadOnlyList<FaceDetectorResult> orderedResults, float thresh)
     {
         float[] x1 = [.. orderedResults.Select(x => x.Box.Left)];
         float[] x2 = [.. orderedResults.Select(x => x.Box.Right)];
@@ -167,11 +176,12 @@ public sealed class ScrfdDetector : IFaceDetectorWithLandmarks, IDisposable
     {
         var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor(_modelParameters.InputName, input) };
         using var outputs = _session.Run(inputs);
+        var outputsList = outputs.ToList();
 
         var strideResults = new List<FaceDetectorResult>();
         foreach (var (idx, stride) in _modelParameters.FeatStrideFpn.Select((val, idx) => (idx, val)))
         {
-            var strideRes = HandleStride(idx, stride, outputs.ToList(), imgSize, scale);
+            var strideRes = HandleStride(idx, stride, outputsList, imgSize, scale);
             strideResults.AddRange(strideRes ?? []);
         }
 
@@ -181,7 +191,7 @@ public sealed class ScrfdDetector : IFaceDetectorWithLandmarks, IDisposable
         }
 
         strideResults.Sort((a, b) => b.Confidence!.Value.CompareTo(a.Confidence!.Value));
-        var keepIdxs = NonMaxSupression(strideResults, Options.NonMaxSupressionThreshold);
+        var keepIdxs = NonMaxSuppression(strideResults, Options.NonMaxSuppressionThreshold);
         return [.. keepIdxs.Select(i => strideResults[i])];
     }
 
@@ -320,7 +330,17 @@ public record ScrfdDetectorOptions
     /// </summary>
     public bool AutoResizeInputToModelDimensions { get; set; } = true;
 
-    public float NonMaxSupressionThreshold { get; set; } = 0.4f;
+    public float NonMaxSuppressionThreshold { get; set; } = 0.4f;
+
+    /// <summary>
+    /// Gets or sets the non max suppression threshold. This is a misspelled alias for <see cref="NonMaxSuppressionThreshold"/>.
+    /// </summary>
+    [Obsolete($"Use {nameof(NonMaxSuppressionThreshold)} instead.")]
+    public float NonMaxSupressionThreshold
+    {
+        get => NonMaxSuppressionThreshold;
+        set => NonMaxSuppressionThreshold = value;
+    }
 
     public float ConfidenceThreshold { get; set; } = 0.5f;
 


### PR DESCRIPTION
A batch of small, low-risk fixes and improvements:

## Fixes for open issues

- **Fixes #70**: `FaceAiSharpBundleFactory.GetExeDir()` now uses `AppContext.BaseDirectory` instead of `Assembly.GetExecutingAssembly().Location`, which returns an empty string in single-file and self-contained deployments.
- **Fixes #81**: The `FaceAiSharp`, `FaceAiSharp.Bundle` and `FaceAiSharp.FaceONNX` nupkgs now include the repository README via `<PackageReadmeFile>` (verified via `dotnet pack`: the file lands in the package and the nuspec references it).

## Robustness

- `IFaceLandmarksDetector.DetectLandmarks` on `ScrfdDetector` threw a `NullReferenceException` when no face was found (`MaxBy` on an empty collection returns `default`). It now throws an `ArgumentException` with a clear message, consistent with `CropProfilePicture`, and a `NotSupportedException` if the model doesn't provide landmarks.
- `ArcFaceEmbeddingsGenerator.GenerateEmbedding` and `OpenVinoOpenClosedEye0001.IsOpen` validated the model's output tensor shape only via `Debug.Assert`, so Release builds would silently compute garbage from an unexpected model. They now throw `InvalidOperationException` with the actual tensor length.

## API cleanup

- Fixed the *NonMaxSuppression* spelling: `ScrfdDetectorOptions.NonMaxSuppressionThreshold` is the new property; the misspelled `NonMaxSupressionThreshold` remains as an `[Obsolete]` alias that forwards to it, so existing code keeps working. The internal `ScrfdDetector.NonMaxSupression` method was renamed accordingly.
- Removed a stale XML doc `<param name="cache">` on the `ScrfdDetector(byte[], ...)` constructor that referenced a removed `IMemoryCache` parameter.
- Hoisted `outputs.ToList()` out of the per-stride loop in `ScrfdDetector.Detect` (it materialized the same list once per stride).

## Testing

- `dotnet test` (net10.0): all 15 tests pass.
- `dotnet pack` for all three packable projects verified to include and reference `README.md`.
- Build produces no new warnings (the four remaining StyleCop warnings pre-date this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HD15kWeCtDUXTnnPLXXuts

---
_Generated by [Claude Code](https://claude.ai/code/session_01HD15kWeCtDUXTnnPLXXuts)_